### PR TITLE
Ensure keyboard markup removal

### DIFF
--- a/NetTelegramBotApi/Types/ReplyKeyboardRemove.cs
+++ b/NetTelegramBotApi/Types/ReplyKeyboardRemove.cs
@@ -17,7 +17,7 @@ namespace NetTelegramBotApi.Types
         /// User will not be able to summon this keyboard.
         /// If you want to hide the keyboard from sight but keep it accessible, use one_time_keyboard in ReplyKeyboardMarkup
         /// </remarks>
-        public bool RemoveKeyboard { get; set; }
+        public bool RemoveKeyboard { get; set; } = true;
 
         /// <summary>
         /// Optional. Use this parameter if you want to hide keyboard for specific users only.


### PR DESCRIPTION
This edition ensures keyboard markup removal when `ReplyKeyboardRemove` type is used in the request by setting a default value so the usage will be changed from:

```c#
await Bot.MakeRequestAsync(new SendMessage(update.Message.Chat.Id, "Test")
{
  ReplyToMessageId = update.Message.MessageId,
  ReplyMarkup = new ReplyKeyboardRemove { RemoveKeyboard = true },
});
```

to:

```c#
await Bot.MakeRequestAsync(new SendMessage(update.Message.Chat.Id, "Test")
{
  ReplyToMessageId = update.Message.MessageId,
  ReplyMarkup = new ReplyKeyboardRemove(), // no need to set any values
});
```